### PR TITLE
Pass route table to management VPC

### DIFF
--- a/templates/main.template
+++ b/templates/main.template
@@ -411,6 +411,10 @@ Resources:
           !GetAtt
           - ProductionVpcTemplate
           - Outputs.rRouteTableProdPrivate
+        pRouteTableProdPrivateB:
+          !GetAtt
+          - ProductionVpcTemplate
+          - Outputs.rRouteTableProdPrivateB
         pRouteTableProdPublic:
           !GetAtt
           - ProductionVpcTemplate


### PR DESCRIPTION
This PR requires this [PR in quickstart-compliance-common](https://github.com/aws-quickstart/quickstart-compliance-common/pull/7) since this one includes that as submodule.

This changes will allow access from the Bastion to resources in private subnet B.