### PR TITLE
Updated files based on Acrolinx feedback.

### DIFF
--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -3,7 +3,7 @@
 :partner-company-name: AWS World Wide Professional Services team
 :doc-month: September
 :doc-year: 2020
-:partner-contributors: Charlie Llewellyn, Chris King, and Matt Johnson, AWS World Wide Professional Services team //TODO Should this be "AWS Professional Services team"?
+:partner-contributors: Charlie Llewellyn, Chris King, and Matt Johnson, AWS Professional Services team
 :quickstart-contributors: Andrew Glenn, AWS Quick Start team
 :deployment_time: 30–60 minutes
 :default_deployment_region: us-east-1

--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -1,9 +1,9 @@
 :quickstart-project-name: quickstart-compliance-uk-official
 :partner-product-name: Standardized Architecture for UK-OFFICIAL
-:partner-company-name: AWS Word Wide Professional Services team
-:doc-month: August
+:partner-company-name: AWS World Wide Professional Services team
+:doc-month: September
 :doc-year: 2020
-:partner-contributors: Charlie Llewellyn, Chris King, and Matt Johnson, AWS Word Wide Professional Services team
+:partner-contributors: Charlie Llewellyn, Chris King, and Matt Johnson, AWS World Wide Professional Services team //TODO Should this be "AWS Professional Services team"?
 :quickstart-contributors: Andrew Glenn, AWS Quick Start team
 :deployment_time: 30–60 minutes
 :default_deployment_region: us-east-1

--- a/docs/partner_editable/architecture.adoc
+++ b/docs/partner_editable/architecture.adoc
@@ -1,8 +1,8 @@
-Deploying this Quick Start builds a multi-VPC network topology, a sample LAMP (Linux Apache MySQL PHP)application and a scalable containerized outbound proxy solution in the AWS Cloud, as illustrated in figures 2, 3, and 4.
+Deploying this Quick Start builds a multi-VPC network topology, a sample LAMP (Linux Apache MySQL PHP) application, and a scalable containerized outbound proxy in the AWS Cloud, as shown in figures 2, 3, and 4.
 
 image::../images/image2.png[image,width=717,height=440]
 
-Figure 2: AWS VPC design depicting integration of a production VPC to host application services, an internet VPC to provide both inbound and outbound connectivity, a shared-services VPC to support common tools (for example, active directory), and an endpoint VPC to provide consolidated access to AWS services and outbound access to the internet. The internet VPC can be replaced or enhanced to feature connectivity to a private government network.
+Figure 2: Amazon Virtual Private Cloud (Amazon VPC) design depicting the integration of a production VPC that hosts application services, an internet VPC that provides both inbound and outbound connectivity, a shared-services VPC that supports common tools (for example, Active Directory), and an endpoint VPC that provides consolidated access to AWS services and outbound access to the internet. The internet VPC can be replaced or enhanced to feature connectivity to a private government network.
 
 image::../images/image4.png[image,width=525,height=732]
 
@@ -10,13 +10,13 @@ Figure 3: Production VPC depicting an integration with an internet VPC for inbou
 
 image::../images/image6.png[image,width=762,height=505]
 
-Figure 4: Production VPC depicting outbound access to the internet via the endpoint VPC, which passes requests to an autoscaling proxy service
+Figure 4: Production VPC depicting outbound access to the internet via the endpoint VPC, which passes requests to an Auto Scaling proxy service
 
 The sample architecture includes the following components and features:
 
 * A basic AWS Identity and Access Management (IAM) configuration with custom IAM policies, associated groups, roles, and instance profiles.
-* An external-facing Amazon Virtual Private Cloud (Amazon VPC) for controlled internet access with Multi-AZ architecture and separate public and private communication.
-* An internal-facing Amazon VPC for shared services (for example, active directory) with a Multi-AZ architecture and private subnets to support shared services.
+* An external-facing Amazon VPC for controlled internet access with Multi-AZ architecture and separate public and private communication.
+* An internal-facing Amazon VPC for shared services (for example, Active Directory) with a Multi-AZ architecture and private subnets to support shared services.
 * An internal-facing Amazon VPC for AWS PrivateLink endpoints to allow direct access to AWS services over the AWS backbone with Multi-AZ architecture and private subnets to support shared services.
 * An internal-facing Amazon VPC for application workloads with Multi-AZ architecture and private subnets to support shared services.
 * AWS Transit Gateway for inter-VPC communication and VPN termination.

--- a/docs/partner_editable/deploy_steps.adoc
+++ b/docs/partner_editable/deploy_steps.adoc
@@ -26,7 +26,7 @@ endif::marketplace_subscription[]
 
 NOTE: You are responsible for the cost of the AWS services used while running this Quick Start reference deployment. There is no additional cost for using this Quick Start. For full details, see the pricing pages for each AWS service used by this Quick Start. Prices are subject to change.
 
-. Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see the link:#_deployment_options[Deployment options] section
+. Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see the link:#_deployment_options[Deployment options] section.
 
 [cols=",]
 |===
@@ -36,7 +36,7 @@ NOTE: You are responsible for the cost of the AWS services used while running th
 
 WARNING: If you deploy {partner-product-name} into an existing VPC, ensure that your VPC has two private subnets in different Availability Zones for the workload instances and that the subnets aren’t shared. This Quick Start doesn’t support https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[shared subnets^]. To download packages and software without exposing them to the internet, these subnets require https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html[NAT gateways^] in their route tables.
 
-Also, ensure that the domain name in the DHCP options is configured. For more information, see http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html[DHCP options sets^]. You must provide your VPC settings when you launch the Quick Start.
+Also, ensure that the domain name in the DHCP options is configured. For more information, see http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html[DHCP options sets^]. Provide your VPC settings when you launch the Quick Start.
 
 Each deployment takes about {deployment_time} to complete.
 

--- a/docs/partner_editable/product_description.adoc
+++ b/docs/partner_editable/product_description.adoc
@@ -3,17 +3,17 @@
 // Include the benefits of using the software on AWS, and provide details on usage scenarios.
 === UK-OFFICIAL compliance on AWS
 
-The deployment guide includes links for viewing and launching AWS CloudFormation templates that automate the deployment, a https://fwd.aws/6AKEy[control mapping matrix], and recommendations for incorporating additional requirements.
+The deployment guide includes links for viewing and launching AWS CloudFormation templates that automate the deployment, a https://fwd.aws/6AKEy[control-mapping matrix], and recommendations for incorporating additional requirements.
 
 
-The purpose of the AWS CloudFormation template is to provide an easily deployable reference architecture for evaluation and testing. Although the template covers many configuration aspects to support UK-OFFICIAL workloads, it is not intended for production workloads without appropriate review and validation.
+The purpose of the AWS CloudFormation template is to provide a deployable reference architecture for evaluation and testing. Although the template covers many configuration aspects to support UK-OFFICIAL workloads, it is not intended for production workloads without appropriate review and validation.
 
 
 Furthermore, organizations must consider their own risks, tolerances, and internal/external requirements before defining and implementing an AWS multiaccount strategy. This includes connectivity with other systems and networks, user authentication workflows, encryption methodologies, logging and auditing requirements, and similar architecture components. We recommend that you customize the AWS CloudFormation templates to meet your needs in order to obtain a repeatable and auditable reference architecture.
 
 === UK government private networks connectivity
 
-AWS customers who require connectivity with special-purpose networks must implement enhanced network segmentation and isolation. Some organizations that may consider doing this include Public Services Network (PSN) for public sector organizations, N3 for English National Health Service (NHS), and Janet for education and research. Such networks are restricted to organizations that have implemented the required set of technical and legal controls as required by their network operators.
+AWS customers who require connectivity with special-purpose networks must implement enhanced network segmentation and isolation. Some organizations that may consider doing this include Public Services Network (PSN) for public-sector organizations, N3 for English National Health Service (NHS), and Janet for education and research. Such networks are restricted to organizations that have implemented the required set of technical and legal controls as required by their network operators.
 
 AWS has worked with private-network providers within the UK government to develop a set of best practices that integrate the included architecture pattern for public-sector organizations to connect to these networks. Contact AWS for guidance.
 

--- a/docs/partner_editable/service_limits.adoc
+++ b/docs/partner_editable/service_limits.adoc
@@ -11,5 +11,5 @@
 |Application Load Balancers |1
 |Network Load Balancers |2
 |t3.micro EC2 instances |7
-|db.t3.micro RDS instances |2
+|db.t3.micro Amazon Relational Database Service (Amazon RDS) instances |2
 |===

--- a/docs/partner_editable/specialized_knowledge.adoc
+++ b/docs/partner_editable/specialized_knowledge.adoc
@@ -1,11 +1,11 @@
 
-This Quick Start requires a moderate to high level of understanding of the process to achieve and manage control requirements and compliance processes associated with UK-OFFICIAL workloads within a traditional hosting environment.
+This Quick Start requires a moderate- to high-level understanding of the process to achieve and manage control requirements and compliance processes associated with UK-OFFICIAL workloads within a traditional hosting environment.
 
 This deployment is intended for information technology (IT) assessors and security personnel. It assumes familiarity with basic security concepts in the areas of networking, operating systems, data encryption, operational controls, and cloud computing.
 
 Additionally, this deployment requires a moderate level of understanding of AWS services, which include the following:
 
 * Access to a current AWS account with IAM administrator-level permissions.
-* A basic understanding of AWS services, AWS service quotas, and AWS CloudFormation.
+* A basic understanding of AWS services, service quotas, and AWS CloudFormation.
 * Knowledge of architecting applications on AWS.
 * An understanding of security and compliance requirements within the customer's organization.


### PR DESCRIPTION
**Additional changes needed**

* Should "AWS World Wide Professional Services" be "AWS Professional Services"? (https://aws.amazon.com/professional-services/)
* In the preview, there doesn't seem to be a figure 1. It jumps to figures 2, 3, and 4 in the Architecture section. (I found Figure 1 under "Launch into a new VPC.")
* The link for "AWS Training and Certification website" should open in a new tab/window. Same with these and many others:
    * "... (see the AWS Shared Responsibility Model) ..." should open in a new tab/window.
    * "AWS Service Catalog" link under "Integrating with AWS Service Catalog" should open in a new tab/window.
    * All links under "Additional resources" should open in a new tab/window.
    * Link under "Quick Start reference deployments"
    *There may be others I missed ...
* Spacing within the yellow boxes is odd. Running text has no space/breaks between paragraphs, but the bullet points do (e.g., "Specialized knowledge" section). Is this an artifact that will be resolved upon final build?
* Yellow boxes in general seem to be applied randomly. For example, why is "Test the deployment" and subsequent sections in a yellow box?
* Under "Deployment steps," it says that "The template launches in the us-east-1 Region by default." Under "Supported Regions," however, eu-west-2 (London) is the only supported Region that's listed
* There's an empty yellow box under "IAM permission."
* Many subheadings have "===" prefixes rather than proper formatting.
* Launch links (x2) under "Deployment steps" don't seem to resolve.
* I didn't find the location of this, but "options" should be capitalized and set in bold: "5. On the options page ..." (under "Launch into a new VPC").
* Image under step 9 is labeled "Figure 1." It's also low-res and hard to read.
* "... as shown in Standardized Architecture for UK-OFFICIAL outputs after successful deployment ..." should be revised to "... as shown in Figure X ..."
* Spell out first mention of Amazon EBS under "Additional resources."
* In general, we should no longer use links labeled "AWS documentation" — they should be specific, e.g., "... see AWS CloudFormation quotas" (with link embedded).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
