### PR TITLE
Update compliance-controls.yaml

### DIFF
--- a/templates/compliance-controls/compliance-controls.yaml
+++ b/templates/compliance-controls/compliance-controls.yaml
@@ -398,7 +398,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSConfigRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWS_ConfigRole
 
   ConfigRecorder:
     Type: AWS::Config::ConfigurationRecorder


### PR DESCRIPTION
*Issue*
Current template fails with following error:

Policy arn:aws:iam::aws:policy/service-role/AWSConfigRole does not exist or is not attachable. (Service: AmazonIdentityManagement; Status Code: 404; Error Code: NoSuchEntity; Request ID: 206ce7c4-eecb-4d5a-a20b-3888e275511e; Proxy: null)

*Description of changes:*
Update deprecated policy AWSConfigRole to AWS_ConfigRole.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
