### PR TITLE
Update outboundProxy.yaml

### DIFF
--- a/templates/outboundProxy/outboundProxy.yaml
+++ b/templates/outboundProxy/outboundProxy.yaml
@@ -31,9 +31,9 @@ Parameters:
     Default: 90
   ContainerImage:
     Type: String
-    Description: The container to use. This can be a dockerhub name (e.g. datadog/squid) or a full ECR path.
+    Description: The container to use. This can be a dockerhub name (e.g. sameersbn/squid) or a full ECR path.
     #Default: chriskingwork/docker-squid:latest
-    Default: datadog/squid:latest
+    Default: sameersbn/squid:latest
   ProjectName:
     Type: String
     Description: Project Name to be used for naming and tagging


### PR DESCRIPTION
*Issue #
Current template throws error:
CannotPullContainerError: pull image manifest has been retried 1 time(s): failed to resolve ref docker.io/datadog/squid:latest: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed

*Description of changes:*
Change datadog for sameersbn as owner of the container _squid_ is hosted by sameersbn now. It does not exists anymore in datadog.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
